### PR TITLE
DRAFT: B-item, changing how hud works

### DIFF
--- a/sprint0/sprint0/Collision/LinkEnemyCollisionHandler.cs
+++ b/sprint0/sprint0/Collision/LinkEnemyCollisionHandler.cs
@@ -7,10 +7,7 @@ namespace sprint0
 
     {
         private readonly int linkSize = (int)(16 * Game1.Scale);
-        public LinkEnemyCollisionHandler()
-        {
-
-        }
+        public LinkEnemyCollisionHandler() { }
 
         public void HandleCollision(IPlayer link, IEnemy enemy, Direction side)
         {

--- a/sprint0/sprint0/Collision/LinkItemCollisionHandler.cs
+++ b/sprint0/sprint0/Collision/LinkItemCollisionHandler.cs
@@ -9,10 +9,7 @@ namespace sprint0
         private readonly int linkSize = (int)(16 * Game1.Scale);
         private readonly int pickUpAnimationTime = 40;
 
-        public LinkItemCollisionHandler(Room room)
-        {
-            this.room = room;
-        }
+        public LinkItemCollisionHandler(Room room) => this.room = room;
 
         public void HandleCollision(IPlayer link, IItem item, Direction side)
         {
@@ -24,7 +21,7 @@ namespace sprint0
                 if (item.PickedUpDuration == -1)
                 {
                     link.PickUpItem();
-                    if( item is GanonTriforceAshes ganon)
+                    if (item is GanonTriforceAshes ganon)
                         room.LoadLevel.RoomEffect.AddEffect(item.Location.Location.ToVector2(), "ganonashes");
                     int itemX = (int)link.Pos.X + linkSize / 2 - item.Location.Width / 2;
                     int itemY = (int)link.Pos.Y - item.Location.Height;
@@ -33,9 +30,7 @@ namespace sprint0
                     room.RoomSound.AddSoundEffect("new item");
                 }
                 else
-                {
                     item.PickedUpDuration = pickUpAnimationTime;
-                }
             }
         }
 
@@ -50,14 +45,11 @@ namespace sprint0
         {
             if (IsSword(item.PlayerItems))
                 link.SetHUDItem(PlayerItems.AItem, item.PlayerItems);
-            if (link.GetItem(PlayerItems.BItem) == PlayerItems.None && !IsSword(item.PlayerItems))
+            else
                 link.SetHUDItem(PlayerItems.BItem, item.PlayerItems);
             link.AddToInventory(item.PlayerItems);
         }
 
-        private bool IsSword(PlayerItems item)
-        {
-            return item == PlayerItems.Sword || item == PlayerItems.WhiteSword || item == PlayerItems.MagicalSword;
-        }
+        private bool IsSword(PlayerItems item) => item == PlayerItems.Sword || item == PlayerItems.WhiteSword || item == PlayerItems.MagicalSword;
     }
 }

--- a/sprint0/sprint0/Game1.cs
+++ b/sprint0/sprint0/Game1.cs
@@ -124,8 +124,10 @@ namespace sprint0
             if (state.Equals(GameStateMachine.State.play) || state.Equals(GameStateMachine.State.test))
             {
                 if (ChangeRoom) LoadContent();
-                else room.Update();
+                room.Update();
             }
+            if (ChangeHUD())
+                hudManager.Update();
             universalScreenManager.Update(state);
             hudManager.Update();
             music.Update();

--- a/sprint0/sprint0/Game1.cs
+++ b/sprint0/sprint0/Game1.cs
@@ -3,7 +3,6 @@ using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace sprint0
 {
@@ -103,9 +102,7 @@ namespace sprint0
                 room = new Room(_spriteBatch, this, RoomIndex, playerPos.X, playerPos.Y, UseLoadedPos);
             }
             else
-            {
                 room = new Room(_spriteBatch, this, RoomIndex);
-            }
             room.LoadContent();
             ChangeRoom = false;
             UseLoadedPos = false;
@@ -124,15 +121,10 @@ namespace sprint0
             if (state.Equals(GameStateMachine.State.play) || state.Equals(GameStateMachine.State.test))
             {
                 if (ChangeRoom) LoadContent();
-
+                else room.Update();
             }
-            if (state.Equals(GameStateMachine.State.play) || state.Equals(GameStateMachine.State.test))
-            {
-
-                room.Update();
-            }
-            hudManager.Update();
             universalScreenManager.Update(state);
+            hudManager.Update();
             music.Update();
             base.Update(gameTime);
         }
@@ -146,7 +138,6 @@ namespace sprint0
             if (ChangeHUD())
                 hudManager.Draw(_spriteBatch);
             universalScreenManager.Draw(_spriteBatch, state);
-
             _spriteBatch.End();
             base.Draw(gameTime);
         }

--- a/sprint0/sprint0/Game1.cs
+++ b/sprint0/sprint0/Game1.cs
@@ -131,8 +131,7 @@ namespace sprint0
 
                 room.Update();
             }
-            if (ChangeHUD())
-                hudManager.Update();
+            hudManager.Update();
             universalScreenManager.Update(state);
             music.Update();
             base.Update(gameTime);

--- a/sprint0/sprint0/Game1.cs
+++ b/sprint0/sprint0/Game1.cs
@@ -30,7 +30,7 @@ namespace sprint0
         public readonly GameStateMachine stateMachine;
 
         private readonly int LinkDefaultX = 250;
-        private readonly int LinkDefaultY = 250;
+        private readonly int LinkDefaultY = 280;
 
         private GameStateMachine.State state;
         public static int Width { get; } = 256;
@@ -63,10 +63,10 @@ namespace sprint0
                 new KeyboardController(this),
                 new MouseController(this)
             };
-
+            ResetManagers();
             soundFactory = new SoundFactory(this);
             music = SoundFactory.MakeBackgroundMusic();
-            ResetManagers();
+
             stateMachine.HandleStart();
             VisitedRooms = new List<int>();
             RoomIndex = 18;
@@ -124,10 +124,11 @@ namespace sprint0
             if (state.Equals(GameStateMachine.State.play) || state.Equals(GameStateMachine.State.test))
             {
                 if (ChangeRoom) LoadContent();
-                
+
             }
-            if (state.Equals(GameStateMachine.State.play) || state.Equals(GameStateMachine.State.test)) {
-               
+            if (state.Equals(GameStateMachine.State.play) || state.Equals(GameStateMachine.State.test))
+            {
+
                 room.Update();
             }
             if (ChangeHUD())

--- a/sprint0/sprint0/HUD/HUD.cs
+++ b/sprint0/sprint0/HUD/HUD.cs
@@ -33,5 +33,6 @@ namespace sprint0
 
         public void Update() { }
         public void SetItem(PlayerItems item) { }
+        public void SetAItem(PlayerItems item) { }
     }
 }

--- a/sprint0/sprint0/HUD/HUDFactory.cs
+++ b/sprint0/sprint0/HUD/HUDFactory.cs
@@ -37,14 +37,9 @@ namespace sprint0
                 "hud" => new HUD(texture, location),
                 "hudA" => new HUDItem(texture, new Vector2((location.X + 153) * Game1.Scale, location.Y + 24 * Game1.Scale)),
                 "hudB" => new HUDItem(texture, new Vector2((location.X + 128) * Game1.Scale, location.Y + 24 * Game1.Scale)),
-                "inventory" => new HUDInventory(game),
-                //"location" => new HUDLocation(texture, location),
                 _ => throw new ArgumentException("Invalid sprite! Sprite factory failed."),
             };
         }
-        public HUDMiniMap MakeMiniMap()
-        {
-            return new HUDMiniMap(game);
-        }
+        public HUDMiniMap MakeMiniMap() => new HUDMiniMap(game);
     }
 }

--- a/sprint0/sprint0/HUD/HUDInventory.cs
+++ b/sprint0/sprint0/HUD/HUDInventory.cs
@@ -31,13 +31,15 @@ namespace sprint0
                 foreach (KeyValuePair<PlayerItems, Rectangle> hudElement in inventoryItems)
                     if (LocationMapping.ContainsKey(hudElement.Key))
                         spriteBatch.Draw(Texture, hudElement.Value, ItemMap[hudElement.Key], Color.White);
-                spriteBatch.Draw(Texture, CurrentItem, ItemMap[Item], Color.White);
+                if (Item != PlayerItems.None)
+                    spriteBatch.Draw(Texture, CurrentItem, ItemMap[Item], Color.White);
             }
         }
 
         public void SetItem(PlayerItems item)
         {
-            Item = item;
+            if (inventoryItems.ContainsKey(item) || item == PlayerItems.None)
+                Item = item;
         }
 
         public void AddItem(PlayerItems newItem)
@@ -95,5 +97,22 @@ namespace sprint0
             else toSwitch = false;
             return toSwitch;
         }
+
+        public void RemoveItem(PlayerItems item)
+        {
+            if (inventoryItems.ContainsKey(item))
+                inventoryItems.Remove(item);
+            if (Item == item)
+                SetItem(PlayerItems.None);
+        }
+
+        public bool HasItem(List<PlayerItems> itemList)
+        {
+            bool hasItem = true;
+            foreach (PlayerItems item in itemList)
+                hasItem = hasItem || inventoryItems.ContainsKey(item);
+            return hasItem;
+        }
+        public bool HasItem(PlayerItems item) => inventoryItems.ContainsKey(item);
     }
 }

--- a/sprint0/sprint0/HUD/HUDInventory.cs
+++ b/sprint0/sprint0/HUD/HUDInventory.cs
@@ -4,15 +4,14 @@ using System;
 using System.Collections.Generic;
 
 //Author: Stuti Shah
-//Updated: 03/25/21 by shah.1440
+//Updated: 04/03/21 by shah.1440
 namespace sprint0
 {
-    public class HUDInventory : HUDItemMapping, IHUD
+    public class HUDInventory : HUDItemMapping
     {
         private Dictionary<PlayerItems, Rectangle> inventoryItems;
         public Dictionary<PlayerItems, Rectangle> InventoryItems { get => inventoryItems; }
-        public List<PlayerItems> AItem { get => aItem; }
-        private List<PlayerItems> aItem;
+        private readonly List<PlayerItems> aItem;
         public Rectangle Location { get; set; }
         public PlayerItems Item { get; set; }
         private readonly int maxItems = 15;
@@ -38,14 +37,14 @@ namespace sprint0
 
         public void SetItem(PlayerItems item)
         {
-            if (inventoryItems.ContainsKey(item) || item == PlayerItems.None)
+            if (HasItem(item) || item == PlayerItems.None)
                 Item = item;
         }
 
         public void AddItem(PlayerItems newItem)
         {
             ToSwitch(newItem);
-            if (!inventoryItems.ContainsKey(newItem) && LocationMapping.ContainsKey(newItem) && inventoryItems.Count <= maxItems)
+            if (!HasItem(newItem) && LocationMapping.ContainsKey(newItem) && inventoryItems.Count <= maxItems)
                 inventoryItems.Add(newItem, LocationMapping[newItem]);
         }
 
@@ -56,7 +55,6 @@ namespace sprint0
         }
 
         public void Update() { }
-
         private void ToSwitch(PlayerItems item)
         {
             switch (item)
@@ -92,15 +90,15 @@ namespace sprint0
         private bool ToSwitchSub(PlayerItems item1, PlayerItems item2)
         {
             bool toSwitch = true;
-            if (inventoryItems.ContainsKey(item1)) inventoryItems.Remove(item2);
-            else if (inventoryItems.ContainsKey(item2)) inventoryItems.Remove(item1);
+            if (HasItem(item1)) inventoryItems.Remove(item2);
+            else if (HasItem(item2)) inventoryItems.Remove(item1);
             else toSwitch = false;
             return toSwitch;
         }
 
         public void RemoveItem(PlayerItems item)
         {
-            if (inventoryItems.ContainsKey(item))
+            if (HasItem(item))
                 inventoryItems.Remove(item);
             if (Item == item)
                 SetItem(PlayerItems.None);
@@ -108,11 +106,12 @@ namespace sprint0
 
         public bool HasItem(List<PlayerItems> itemList)
         {
-            bool hasItem = true;
+            bool hasItem = false;
             foreach (PlayerItems item in itemList)
-                hasItem = hasItem || inventoryItems.ContainsKey(item);
+                hasItem = hasItem || HasItem(item);
             return hasItem;
         }
+        public bool HasAItem() => aItem.Count != 0;
         public bool HasItem(PlayerItems item) => inventoryItems.ContainsKey(item);
     }
 }

--- a/sprint0/sprint0/HUD/HUDItem.cs
+++ b/sprint0/sprint0/HUD/HUDItem.cs
@@ -33,7 +33,7 @@ namespace sprint0
 
         public void SetItem(PlayerItems item)
         {
-            if (ItemMap.ContainsKey(item) || item == PlayerItems.None)
+            if ((ItemMap.ContainsKey(item) && Item == PlayerItems.None) || item == PlayerItems.None)
                 Item = item;
         }
 

--- a/sprint0/sprint0/HUD/HUDItem.cs
+++ b/sprint0/sprint0/HUD/HUDItem.cs
@@ -4,7 +4,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 //Author: Stuti Shah
-//Updated: 03/24/21 by shah.1440
+//Updated: 04/03/21 by shah.1440
 namespace sprint0
 {
     public class HUDItem : HUDItemMapping, IHUD
@@ -31,12 +31,18 @@ namespace sprint0
 
         public void Update() { }
 
+        public void SetAItem(PlayerItems item)
+        {
+            if ((ItemMap.ContainsKey(item) && IsSword(item)) || item == PlayerItems.None)
+                Item = item;
+        }
         public void SetItem(PlayerItems item)
         {
-            if ((ItemMap.ContainsKey(item) && Item == PlayerItems.None) || item == PlayerItems.None)
+            if (ItemMap.ContainsKey(item) && Item == PlayerItems.None || item == PlayerItems.None)
                 Item = item;
         }
 
         private bool SmallItem() => Item != PlayerItems.Compass && Item != PlayerItems.Raft && Item != PlayerItems.StepLadder;
+        private bool IsSword(PlayerItems item) => item == PlayerItems.Sword || item == PlayerItems.MagicalSword || item == PlayerItems.WhiteSword;
     }
 }

--- a/sprint0/sprint0/HUD/HUDItem.cs
+++ b/sprint0/sprint0/HUD/HUDItem.cs
@@ -23,22 +23,20 @@ namespace sprint0
         }
         public void Draw(SpriteBatch spriteBatch)
         {
-            if (Item != PlayerItems.None && SmallItem()) spriteBatch.Draw(Texture, new Rectangle(Location.X, Location.Y, (int)(Width * Game1.Scale), (int)(Height * Game1.Scale)), ItemMap[Item], Color.White);
-            else if (Item != PlayerItems.None) spriteBatch.Draw(Texture, new Rectangle((Location.X - Width - 1), Location.Y, (int)(Width * 2 * Game1.Scale), (int)(Height * Game1.Scale)), ItemMap[Item], Color.White);
+            if (Item != PlayerItems.None && SmallItem())
+                spriteBatch.Draw(Texture, new Rectangle(Location.X, Location.Y, (int)(Width * Game1.Scale), (int)(Height * Game1.Scale)), ItemMap[Item], Color.White);
+            else if (Item != PlayerItems.None)
+                spriteBatch.Draw(Texture, new Rectangle((Location.X - Width - 1), Location.Y, (int)(Width * 2 * Game1.Scale), (int)(Height * Game1.Scale)), ItemMap[Item], Color.White);
         }
 
-        public void Update()
-        {
-        }
+        public void Update() { }
 
         public void SetItem(PlayerItems item)
         {
-            if (ItemMap.ContainsKey(item)) Item = item;
+            if (ItemMap.ContainsKey(item) || item == PlayerItems.None)
+                Item = item;
         }
 
-        private bool SmallItem()
-        {
-            return Item != PlayerItems.Compass && Item != PlayerItems.Raft && Item != PlayerItems.StepLadder;
-        }
+        private bool SmallItem() => Item != PlayerItems.Compass && Item != PlayerItems.Raft && Item != PlayerItems.StepLadder;
     }
 }

--- a/sprint0/sprint0/HUD/HUDItemMapping.cs
+++ b/sprint0/sprint0/HUD/HUDItemMapping.cs
@@ -4,7 +4,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 //Author: Stuti Shah
-//Updated: 03/25/21 by shah.1440
+//Updated: 04/03/21 by shah.1440
 namespace sprint0
 {
     public class HUDItemMapping
@@ -47,39 +47,32 @@ namespace sprint0
                 { PlayerItems.PowerBracelet, GetSource(590, YPos+19)},
                 { PlayerItems.Map, GetSource(601, YPos+19)},
                 { PlayerItems.Compass, GetSourceCompass(614, YPos+19)},
-                { PlayerItems.Raft, GetSourceRaftLadder(520, YPos+19)},
+                { PlayerItems.Raft, GetSourceRaftLadder(521, YPos+19)},
                 { PlayerItems.StepLadder, GetSourceRaftLadder(560, YPos+19)},
+                { PlayerItems.ItemSelectorRed, GetSourceRaftLadder(519, YPos)},
+                { PlayerItems.ItemSelectorBlue, GetSourceRaftLadder(536, YPos)},
             };
 
             locationMapping = new Dictionary<PlayerItems, Rectangle>
             {
                 { PlayerItems.Raft, GetSource(129, yPosTop, bigWidth, height)},
                 { PlayerItems.BookOfMagic, GetSource(152, yPosTop, smallWidth, height) },
-
                 { PlayerItems.RedRing, GetSource(164, yPosTop, smallWidth, height) },
-
                 { PlayerItems.StepLadder, GetSource(176, yPosTop, bigWidth, height) },
                 { PlayerItems.MagicalKey, GetSource(196, yPosTop, smallWidth, height) },
                 { PlayerItems.PowerBracelet, GetSource(208, yPosTop, smallWidth, height) },
-
                 { PlayerItems.MagicalBoomerang, GetSource(132, yPosMiddle, smallWidth, height) },
                 { PlayerItems.Boomerang, GetSource(132, yPosMiddle, smallWidth, height) },
-
                 { PlayerItems.Bomb, GetSource(156, yPosMiddle, smallWidth, height) },
                 { PlayerItems.Bow, GetSource(184, yPosMiddle, smallWidth, height) },
-
                 { PlayerItems.Arrow, GetSource(176, yPosMiddle, smallWidth, height) },
                 { PlayerItems.SilverArrow, GetSource(176, yPosMiddle, smallWidth, height) },
-
                 { PlayerItems.RedCandle, GetSource(204, yPosMiddle, smallWidth, height) },
                 { PlayerItems.BlueCandle, GetSource(204, yPosMiddle, smallWidth, height) },
-
                 { PlayerItems.Flute, GetSource(132, yPosBottom, smallWidth, height) },
                 { PlayerItems.Food, GetSource(156, yPosBottom, smallWidth, height) },
-
                 { PlayerItems.RedPotion, GetSource(180, yPosBottom, smallWidth, height) },
                 { PlayerItems.BluePotion, GetSource(180, yPosBottom, smallWidth, height) },
-
                 { PlayerItems.MagicalRod, GetSource(204, yPosBottom, smallWidth, height) },
                 { PlayerItems.Map, GetSource(48, yPosTop+mapHeight, smallWidth, height) },
                 { PlayerItems.Compass, GetSource(44, yPosBottom+mapHeight, bigWidth-1, height) },
@@ -87,21 +80,10 @@ namespace sprint0
             currentItem = GetSource(currentItemX, yPosMiddle, smallWidth, height);
         }
 
-        private Rectangle GetSource(int xPos, int yPos)
-        {
-            return new Rectangle(xPos, yPos, Width, Height);
-        }
-        private Rectangle GetSourceCompass(int xPos, int yPos)
-        {
-            return new Rectangle(xPos, yPos, Width + 3, Height);
-        }
-        private Rectangle GetSourceRaftLadder(int xPos, int yPos)
-        {
-            return new Rectangle(xPos, yPos, Width * 2, Height);
-        }
+        private Rectangle GetSource(int xPos, int yPos) => new Rectangle(xPos, yPos, Width, Height);
+        private Rectangle GetSourceCompass(int xPos, int yPos) => new Rectangle(xPos, yPos, Width + 3, Height);
+        private Rectangle GetSourceRaftLadder(int xPos, int yPos) => new Rectangle(xPos, yPos, Width * 2, Height);
         private Rectangle GetSource(int xPos, int yPos, int width, int height)
-        {
-            return new Rectangle((int)(xPos * Game1.Scale), (int)((yPos + Game1.HUDHeight) * Game1.Scale), (int)(width * Game1.Scale), (int)(height * Game1.Scale));
-        }
+            => new Rectangle((int)(xPos * Game1.Scale), (int)((yPos + Game1.HUDHeight) * Game1.Scale), (int)(width * Game1.Scale), (int)(height * Game1.Scale));
     }
 }

--- a/sprint0/sprint0/HUD/HUDManager.cs
+++ b/sprint0/sprint0/HUD/HUDManager.cs
@@ -23,26 +23,21 @@ namespace sprint0
         private PlayerItems currentItem;
         private int health;
 
-
         public HUDManager(Game1 game)
         {
             this.game = game;
             mainHUD = new MainHUD(this.game);
             currentItem = PlayerItems.None;
-            pauseInventory = game.universalScreenManager.pauseScreenManager.HUDInventory;
+            pauseInventory = game.universalScreenManager.PauseScreenManager.Inventory();
             populateHUDInventory = new PopulateHUDInventory(this.game);
-            //health = populateHUDInventory.GetNum(PlayerItems.Heart);
         }
 
         public void Update()
         {
-            Refresh();
-
             populateHUDInventory.Update();
             health = populateHUDInventory.GetNum(PlayerItems.Heart);
             mainHUD.Update();
             currentItem = mainHUD.GetItem(PlayerItems.BItem);
-            pauseInventory.Update();
         }
 
         public void Draw(SpriteBatch spriteBatch)
@@ -58,16 +53,9 @@ namespace sprint0
         }
         public bool HasItem(PlayerItems item) => pauseInventory.HasItem(item);
         public bool HasBowAndArrow() => pauseInventory.HasItem(PlayerItems.Bow) && pauseInventory.HasItem(arrowList);
-        public bool HasSword() => pauseInventory.HasItem(swordList);
-        public bool HasBlueCandle() => pauseInventory.HasItem(PlayerItems.BlueCandle);
+        public bool HasSword() => pauseInventory.HasAItem();
         public bool CanUseBomb() => pauseInventory.HasItem(PlayerItems.Bomb) && (populateHUDInventory.GetNum(PlayerItems.Bomb) > 0);
         public bool HasBoomerang() => pauseInventory.HasItem(boomerangList);
-        public bool HasMap() => pauseInventory.HasItem(PlayerItems.Map);
-        public bool HasCompass() => pauseInventory.HasItem(PlayerItems.Compass);
-
-        private void Refresh() => pauseInventory = game.universalScreenManager.pauseScreenManager.HUDInventory;
-
-        public PlayerItems GetBItem() => mainHUD.GetItem(PlayerItems.BItem);
         public void AddBItem(PlayerItems item) => pauseInventory.AddItem(item);
         public void SetItem(PlayerItems source, PlayerItems item)
         {
@@ -91,5 +79,10 @@ namespace sprint0
         public void Increment(PlayerItems item) => populateHUDInventory.IncrementItem(item);
         public void Decrement(PlayerItems item) => populateHUDInventory.DecrementItem(item);
         public void TakeDamage(int damage) => health = populateHUDInventory.TakeDamage(damage);
+        public void SetBItem(PlayerItems item)
+        {
+            currentItem = item;
+            mainHUD.UpdateBItem(item);
+        }
     }
 }

--- a/sprint0/sprint0/HUD/HUDManager.cs
+++ b/sprint0/sprint0/HUD/HUDManager.cs
@@ -83,7 +83,7 @@ namespace sprint0
         }
         public void RemoveBomb()
         {
-            if (!CanUseBomb())
+            if (!CanUseBomb() && currentItem == PlayerItems.Bomb)
                 RemoveBItem(PlayerItems.Bomb);
         }
         public void GainHealth(int num) => populateHUDInventory.GainHealth(num);

--- a/sprint0/sprint0/HUD/HUDManager.cs
+++ b/sprint0/sprint0/HUD/HUDManager.cs
@@ -4,34 +4,45 @@ using System;
 using System.Collections.Generic;
 
 //Author: Stuti Shah
-//Updated: 03/26/21 by shah.1440
+//Updated: 04/03/21 by shah.1440
 namespace sprint0
 {
     public class HUDManager
     {
         private Game1 game;
         private PopulateHUDInventory populateHUDInventory;
-        public PopulateHUDInventory PopulateHUDInventory { get => populateHUDInventory; }
-        private MainHUD mainHUD;
-        private Dictionary<PlayerItems, Rectangle> inventory;
-        private List<PlayerItems> aItem;
-        public MainHUD MainHUD { get => mainHUD; }
+        private readonly MainHUD mainHUD;
+        private HUDInventory pauseInventory;
+        private List<PlayerItems>
+            swordList = new List<PlayerItems> { PlayerItems.Sword, PlayerItems.WhiteSword, PlayerItems.MagicalSword },
+            arrowList = new List<PlayerItems> { PlayerItems.Arrow, PlayerItems.SilverArrow },
+            boomerangList = new List<PlayerItems> { PlayerItems.Boomerang, PlayerItems.MagicalBoomerang };
+
+        public int Health { get => health; set => health = value; }
+        public PlayerItems CurrentItem { get => currentItem; }
+        private PlayerItems currentItem;
+        private int health;
+
 
         public HUDManager(Game1 game)
         {
             this.game = game;
             mainHUD = new MainHUD(this.game);
+            currentItem = PlayerItems.None;
+            pauseInventory = game.universalScreenManager.pauseScreenManager.HUDInventory;
             populateHUDInventory = new PopulateHUDInventory(this.game);
-            inventory = game.universalScreenManager.pauseScreenManager.Inventory();
-            aItem = game.universalScreenManager.pauseScreenManager.AItems();
+            //health = populateHUDInventory.GetNum(PlayerItems.Heart);
         }
 
         public void Update()
         {
-            inventory = game.universalScreenManager.pauseScreenManager.Inventory();
-            aItem = game.universalScreenManager.pauseScreenManager.AItems();
+            Refresh();
+
             populateHUDInventory.Update();
+            health = populateHUDInventory.GetNum(PlayerItems.Heart);
             mainHUD.Update();
+            currentItem = mainHUD.GetItem(PlayerItems.BItem);
+            pauseInventory.Update();
         }
 
         public void Draw(SpriteBatch spriteBatch)
@@ -45,47 +56,40 @@ namespace sprint0
             mainHUD.PopulateMainHUD();
             populateHUDInventory.PopulateInventoryHUD();
         }
+        public bool HasItem(PlayerItems item) => pauseInventory.HasItem(item);
+        public bool HasBowAndArrow() => pauseInventory.HasItem(PlayerItems.Bow) && pauseInventory.HasItem(arrowList);
+        public bool HasSword() => pauseInventory.HasItem(swordList);
+        public bool HasBlueCandle() => pauseInventory.HasItem(PlayerItems.BlueCandle);
+        public bool CanUseBomb() => pauseInventory.HasItem(PlayerItems.Bomb) && (populateHUDInventory.GetNum(PlayerItems.Bomb) > 0);
+        public bool HasBoomerang() => pauseInventory.HasItem(boomerangList);
+        public bool HasMap() => pauseInventory.HasItem(PlayerItems.Map);
+        public bool HasCompass() => pauseInventory.HasItem(PlayerItems.Compass);
 
-        public bool HasBowAndArrow()
-        {
-            return (inventory.ContainsKey(PlayerItems.Arrow) || inventory.ContainsKey(PlayerItems.SilverArrow)) && inventory.ContainsKey(PlayerItems.Bow);
-        }
+        private void Refresh() => pauseInventory = game.universalScreenManager.pauseScreenManager.HUDInventory;
 
-        public bool HasSword()
+        public PlayerItems GetBItem() => mainHUD.GetItem(PlayerItems.BItem);
+        public void AddBItem(PlayerItems item) => pauseInventory.AddItem(item);
+        public void SetItem(PlayerItems source, PlayerItems item)
         {
-            return aItem.Contains(PlayerItems.Sword) || aItem.Contains(PlayerItems.WhiteSword) || aItem.Contains(PlayerItems.MagicalSword);
+            mainHUD.SetItem(source, item);
+            if (source == PlayerItems.BItem)
+                pauseInventory.SetItem(item);
+            else pauseInventory.AddAItem(item);
         }
-
-        public bool HasBlueCandle()
+        public void RemoveBItem(PlayerItems item)
         {
-            return inventory.ContainsKey(PlayerItems.BlueCandle);
+            mainHUD.RemoveBItem();
+            pauseInventory.RemoveItem(item);
         }
-
-        public bool CanUseBomb()
+        public void RemoveBomb()
         {
-            return inventory.ContainsKey(PlayerItems.Bomb) && (populateHUDInventory.GetNum(PlayerItems.Bomb) > 0);
+            if (!CanUseBomb())
+                RemoveBItem(PlayerItems.Bomb);
         }
-
-        public bool HasBoomerang()
-        {
-            return inventory.ContainsKey(PlayerItems.MagicalBoomerang) || inventory.ContainsKey(PlayerItems.Boomerang);
-        }
-
-        public bool HasMap()
-        {
-            return inventory.ContainsKey(PlayerItems.Map);
-        }
-
-        public bool HasCompass()
-        {
-            return inventory.ContainsKey(PlayerItems.Compass);
-        }
-
-        public void Refresh()
-        {
-            populateHUDInventory = new PopulateHUDInventory(game);
-            inventory = game.universalScreenManager.pauseScreenManager.Inventory();
-            aItem = game.universalScreenManager.pauseScreenManager.AItems();
-        }
+        public void GainHealth(int num) => populateHUDInventory.GainHealth(num);
+        public void ChangeNum(PlayerItems item, int num) => populateHUDInventory.ChangeNum(item, num);
+        public void Increment(PlayerItems item) => populateHUDInventory.IncrementItem(item);
+        public void Decrement(PlayerItems item) => populateHUDInventory.DecrementItem(item);
+        public void TakeDamage(int damage) => health = populateHUDInventory.TakeDamage(damage);
     }
 }

--- a/sprint0/sprint0/HUD/HUDMiniMap.cs
+++ b/sprint0/sprint0/HUD/HUDMiniMap.cs
@@ -18,10 +18,9 @@ namespace sprint0
             currentRoom = this.game.RoomIndex;
         }
 
-
         public void Draw(SpriteBatch spriteBatch)
         {
-            if (game.hudManager.HasMap())
+            if (game.hudManager.HasItem(PlayerItems.Map))
                 DrawMap(spriteBatch);
             DrawLocation(spriteBatch);
         }

--- a/sprint0/sprint0/HUD/HeartHUD.cs
+++ b/sprint0/sprint0/HUD/HeartHUD.cs
@@ -14,7 +14,9 @@ namespace sprint0
         public int CurrentNum { get => currentHealth; }
         private readonly int[] heartState;
         private readonly List<Rectangle> sources;
-        private readonly int sideLength = 8, heartType = 3, heartsPerRow = 8, healthToHeart = 2, reset = 0, xOffset = 627, yOffset = 117, maxPossibleHearts = 32;
+        private readonly int sideLength = 8, heartType = 3, heartsPerRow = 8,
+            healthToHeart = 2, reset = 0, xOffset = 627,
+            yOffset = 117, maxPossibleHearts = 32;
         private int currentHealth, numHearts = 15, maxHealth = 30;
 
         public HeartHUD(Texture2D texture, Vector2 location)
@@ -71,14 +73,10 @@ namespace sprint0
             }
         }
 
-        public void Decrement()
-        {
-        }
+        public void Decrement() { }
 
-        public void ResetNum()
-        {
-            currentHealth = maxHealth;
-        }
+        public void ResetNum() => currentHealth = maxHealth;
+
         public void ZeroHealth()
         {
             currentHealth = reset;

--- a/sprint0/sprint0/HUD/ItemSelection.cs
+++ b/sprint0/sprint0/HUD/ItemSelection.cs
@@ -1,15 +1,91 @@
 ﻿using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
 namespace sprint0
 {
-    public class ItemSelection
+    public class ItemSelection : HUDItemMapping, ISprite
     {
-        public ItemSelection()
+        private List<PlayerItems> itemList;
+        public Rectangle Location { get; set; }
+        private Dictionary<PlayerItems, Rectangle> inventoryItems;
+        private readonly int itemNum = 19, totalFrames = 2, repeatedFrames = 30;
+        private int index, currentFrame = 0, pos;
+        private readonly List<Rectangle> sources;
+        public Texture2D Texture { get; set; }
+        public ItemSelection(Game1 game)
         {
+            Texture = new HUDFactory(game).Texture;
+            ResetIndex();
+            inventoryItems = new Dictionary<PlayerItems, Rectangle>();
+            sources = new List<Rectangle> { ItemMap[PlayerItems.ItemSelectorRed], ItemMap[PlayerItems.ItemSelectorBlue] };
+            itemList = new List<PlayerItems> {
+                PlayerItems.Raft,
+                PlayerItems.BookOfMagic,
+                PlayerItems.RedRing,
+                PlayerItems.StepLadder,
+                PlayerItems.MagicalKey,
+                PlayerItems.PowerBracelet,
+                PlayerItems.MagicalBoomerang,
+                PlayerItems.Boomerang,
+                PlayerItems.Bomb,
+                PlayerItems.Bow,
+                PlayerItems.Arrow,
+                PlayerItems.SilverArrow,
+                PlayerItems.RedCandle,
+                PlayerItems.BlueCandle,
+                PlayerItems.Flute,
+                PlayerItems.Food,
+                PlayerItems.RedPotion,
+                PlayerItems.BluePotion,
+                PlayerItems.MagicalRod,
+                PlayerItems.None,
+            };
         }
+
+        public void GetCurrentItem(PlayerItems item)
+        {
+            if (Handle())
+                index = itemList.IndexOf(item);
+        }
+        public void GetInventory(Dictionary<PlayerItems, Rectangle> items) => inventoryItems = items;
+        public PlayerItems GetSelectedItem() => ItemAtIndex();
+        public void Draw(SpriteBatch spriteBatch)
+        {
+            pos = index;
+            if (BowRange()) pos++;
+            if (Handle() && itemList[index] != PlayerItems.None)
+                spriteBatch.Draw(Texture, GetRectangle(), sources[currentFrame / repeatedFrames], Color.White);
+        }
+        private bool Handle() => inventoryItems.Count != 0;
+        private void ResetIndex() => index = itemNum;
+
+        public void HandleLeft()
+        {
+            index = (index + itemNum - 1) % itemNum;
+            while (Search())
+                index = (index + itemNum - 1) % itemNum;
+            ResetColor();
+        }
+
+        public void HandleRight()
+        {
+            index = (index + 1) % itemNum;
+            while (Search())
+                index = (index + 1) % itemNum;
+            ResetColor();
+        }
+        private bool Search() => !InventoryHas() && Handle();
+        private void ResetColor() => currentFrame = 0;
+
+        private PlayerItems ItemAtIndex() => itemList[index];
+        private PlayerItems ItemAtIndex(int position) => itemList[position];
+        private bool InventoryHas() => inventoryItems.ContainsKey(ItemAtIndex());
+        private Rectangle GetRectangle()
+            => new Rectangle(LocationMapping[ItemAtIndex(pos)].X, LocationMapping[ItemAtIndex(pos)].Y,
+                (int)(Height * Game1.Scale), (int)(Height * Game1.Scale));
+        public void Update() => currentFrame = (currentFrame + 1) % (totalFrames * repeatedFrames);
+        private bool BowRange() => index == itemList.IndexOf(PlayerItems.Bow);
     }
 }
-
-
-//the square thing; being able to move it l/r/u/d
-//current item changing with each one (update pause menu)
-//clicking b will select the item (update hud manager and main hud)

--- a/sprint0/sprint0/HUD/ItemSelection.cs
+++ b/sprint0/sprint0/HUD/ItemSelection.cs
@@ -1,0 +1,15 @@
+﻿using System;
+namespace sprint0
+{
+    public class ItemSelection
+    {
+        public ItemSelection()
+        {
+        }
+    }
+}
+
+
+//the square thing; being able to move it l/r/u/d
+//current item changing with each one (update pause menu)
+//clicking b will select the item (update hud manager and main hud)

--- a/sprint0/sprint0/HUD/MainHUD.cs
+++ b/sprint0/sprint0/HUD/MainHUD.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 
 //Author: Stuti Shah
-//Updated: 03/24/21 by shah.1440
+//Updated: 04/03/21 by shah.1440
 namespace sprint0
 {
     public class MainHUD
@@ -46,8 +46,9 @@ namespace sprint0
 
         public void SetItem(PlayerItems source, PlayerItems newItem)
         {
-            if (hudMainItems.ContainsKey(source))
-                hudMainItems[source].SetItem(newItem);
+            if (hudMainItems.ContainsKey(source) && source == PlayerItems.AItem)
+                hudMainItems[source].SetAItem(newItem);
+            else hudMainItems[source].SetItem(newItem);
         }
 
         public void Update() => hudMiniMap.Update();

--- a/sprint0/sprint0/HUD/MainHUD.cs
+++ b/sprint0/sprint0/HUD/MainHUD.cs
@@ -44,12 +44,12 @@ namespace sprint0
 
         public void SetItem(PlayerItems source, PlayerItems newItem)
         {
-            if (hudMainItems.ContainsKey(source)) hudMainItems[source].SetItem(newItem);
+            if (hudMainItems.ContainsKey(source))
+                hudMainItems[source].SetItem(newItem);
         }
 
-        public void Update()
-        {
-            hudMiniMap.Update();
-        }
+        public void Update() => hudMiniMap.Update();
+
+        public void RemoveBItem() => hudMainItems[PlayerItems.BItem].SetItem(PlayerItems.None);
     }
 }

--- a/sprint0/sprint0/HUD/MainHUD.cs
+++ b/sprint0/sprint0/HUD/MainHUD.cs
@@ -29,6 +29,8 @@ namespace sprint0
             hudMiniMap = hudFactory.MakeMiniMap();
         }
 
+        public void UpdateBItem(PlayerItems item) => hudMainItems[PlayerItems.BItem].Item = item;
+
         public void Draw(SpriteBatch spriteBatch)
         {
             foreach (KeyValuePair<PlayerItems, IHUD> hudElement in hudMainItems)

--- a/sprint0/sprint0/HUD/PopulateHUDInventory.cs
+++ b/sprint0/sprint0/HUD/PopulateHUDInventory.cs
@@ -13,10 +13,7 @@ namespace sprint0
         private readonly HUDFactory hudFactory;
         private Dictionary<PlayerItems, IHUDInventory> inventory;
 
-        public PopulateHUDInventory(Game1 game)
-        {
-            hudFactory = new HUDFactory(game);
-        }
+        public PopulateHUDInventory(Game1 game) => hudFactory = new HUDFactory(game);
 
         public void PopulateInventoryHUD()
         {
@@ -32,17 +29,13 @@ namespace sprint0
         public void DrawItemHUD(SpriteBatch spriteBatch)
         {
             foreach (KeyValuePair<PlayerItems, IHUDInventory> hudElement in inventory)
-            {
                 hudElement.Value.Draw(spriteBatch);
-            }
         }
 
         public void Update()
         {
             foreach (KeyValuePair<PlayerItems, IHUDInventory> hudElement in inventory)
-            {
                 hudElement.Value.Update();
-            }
         }
 
         public void IncrementItem(PlayerItems item)
@@ -60,9 +53,12 @@ namespace sprint0
             if (inventory.ContainsKey(item)) inventory[item].ChangeNum(num);
         }
 
-        public int GetNum(PlayerItems item)
+        public int GetNum(PlayerItems item) => inventory[item].CurrentNum;
+        public int TakeDamage(int damage)
         {
-            return inventory[item].CurrentNum;
+            inventory[PlayerItems.Heart].ChangeNum(damage);
+            return inventory[PlayerItems.Heart].CurrentNum;
         }
+        public void GainHealth(int num) => inventory[PlayerItems.Heart].ChangeNum(-1 * num);
     }
 }

--- a/sprint0/sprint0/Input/Command/BItemCommand.cs
+++ b/sprint0/sprint0/Input/Command/BItemCommand.cs
@@ -1,0 +1,48 @@
+﻿// Author: Stuti Shah
+using System.Collections.Generic;
+
+namespace sprint0
+{
+    class BItemCommand : ICommand
+    {
+        private readonly Game1 game;
+        private readonly Dictionary<PlayerItems, ICommand> commands;
+        private PlayerItems BItem;
+
+        public BItemCommand(Game1 game)
+        {
+            this.game = game;
+            commands = new Dictionary<PlayerItems, ICommand>
+            {
+                { PlayerItems.Arrow, new OneCommand(this.game) },
+                { PlayerItems.SilverArrow, new OneCommand(this.game) },
+                { PlayerItems.Bomb, new TwoCommand(this.game) },
+                { PlayerItems.Boomerang, new ThreeCommand(this.game) },
+                { PlayerItems.MagicalBoomerang, new ThreeCommand(this.game) },
+                { PlayerItems.RedPotion, new PotionCommand(this.game) },
+                //{ PlayerItems.BluePotion, new PotionCommand(this.game) },
+                { PlayerItems.Food, new FoodCommand(this.game) },
+                { PlayerItems.BlueCandle, new FourCommand(this.game) },
+                //{ PlayerItems.RedCandle, new FourCommand(this.game) },
+                /*rings*/
+                /*magical rod*/
+                /*flute*/
+            };
+        }
+
+        public void Execute()
+        {
+            BItem = game.hudManager.CurrentItem;
+            if (PlayOrPause() && Contains())
+                commands[BItem].Execute();
+        }
+        private bool PlayOrPause()
+        {
+            return game.stateMachine.GetState() != GameStateMachine.State.play || game.stateMachine.GetState() != GameStateMachine.State.test;
+        }
+        private bool Contains()
+        {
+            return commands.ContainsKey(BItem);
+        }
+    }
+}

--- a/sprint0/sprint0/Input/Command/BItemCommand.cs
+++ b/sprint0/sprint0/Input/Command/BItemCommand.cs
@@ -7,7 +7,6 @@ namespace sprint0
     {
         private readonly Game1 game;
         private readonly Dictionary<PlayerItems, ICommand> commands;
-        private PlayerItems BItem;
 
         public BItemCommand(Game1 game)
         {
@@ -20,29 +19,32 @@ namespace sprint0
                 { PlayerItems.Boomerang, new ThreeCommand(this.game) },
                 { PlayerItems.MagicalBoomerang, new ThreeCommand(this.game) },
                 { PlayerItems.RedPotion, new PotionCommand(this.game) },
-                //{ PlayerItems.BluePotion, new PotionCommand(this.game) },
+                { PlayerItems.BluePotion, new PotionCommand(this.game) },
                 { PlayerItems.Food, new FoodCommand(this.game) },
                 { PlayerItems.BlueCandle, new FourCommand(this.game) },
-                //{ PlayerItems.RedCandle, new FourCommand(this.game) },
-                /*rings*/
-                /*magical rod*/
-                /*flute*/
+                { PlayerItems.RedCandle, new FourCommand(this.game) },
             };
         }
 
         public void Execute()
         {
-            BItem = game.hudManager.CurrentItem;
-            if (PlayOrPause() && Contains())
-                commands[BItem].Execute();
+            if (game.stateMachine.GetState() == GameStateMachine.State.pause)
+            {
+                game.universalScreenManager.Update(GameStateMachine.State.pause);
+                game.hudManager.SetBItem(game.universalScreenManager.BItem());
+
+                game.stateMachine.HandlePause();
+            }
+            else if (PlayOrTest() && Contains(game.hudManager.CurrentItem))
+                commands[game.hudManager.CurrentItem].Execute();
         }
-        private bool PlayOrPause()
+        private bool PlayOrTest()
         {
             return game.stateMachine.GetState() != GameStateMachine.State.play || game.stateMachine.GetState() != GameStateMachine.State.test;
         }
-        private bool Contains()
+        private bool Contains(PlayerItems item)
         {
-            return commands.ContainsKey(BItem);
+            return commands.ContainsKey(item);
         }
     }
 }

--- a/sprint0/sprint0/Input/Command/FoodCommand.cs
+++ b/sprint0/sprint0/Input/Command/FoodCommand.cs
@@ -1,0 +1,20 @@
+﻿// Author: Stuti Shah
+namespace sprint0
+{
+    class FoodCommand : ICommand
+    {
+        private readonly Game1 game;
+        private HUDManager HUD;
+        private PlayerItems item = PlayerItems.Food;
+        private int health = 5;
+
+        public FoodCommand(Game1 game) => this.game = game;
+
+        public void Execute()
+        {
+            HUD = game.hudManager;
+            HUD.RemoveBItem(item);
+            HUD.GainHealth(health);
+        }
+    }
+}

--- a/sprint0/sprint0/Input/Command/FourCommand.cs
+++ b/sprint0/sprint0/Input/Command/FourCommand.cs
@@ -5,14 +5,11 @@ namespace sprint0
     {
         private readonly Game1 game;
 
-        public FourCommand(Game1 game)
-        {
-            this.game = game;
-        }
+        public FourCommand(Game1 game) => this.game = game;
 
         public void Execute()
         {
-            if (game.hudManager.HasBlueCandle() || game.stateMachine.GetState().Equals(GameStateMachine.State.test)) //Take out TestMode when not needed
+            if (game.hudManager.HasItem(PlayerItems.BlueCandle) || game.stateMachine.GetState().Equals(GameStateMachine.State.test)) //Take out TestMode when not needed
             {
                 game.Room.Player.CurrentItem = PlayerItems.BlueCandle;
                 game.Room.Player.HandleItem();

--- a/sprint0/sprint0/Input/Command/LeftCommand.cs
+++ b/sprint0/sprint0/Input/Command/LeftCommand.cs
@@ -12,7 +12,8 @@ namespace sprint0
 
         public void Execute()
         {
-            game.Room.Player.HandleLeft();
+            if (game.stateMachine.GetState() != GameStateMachine.State.pause)
+                game.Room.Player.HandleLeft();
         }
     }
 }

--- a/sprint0/sprint0/Input/Command/LeftItemCommand.cs
+++ b/sprint0/sprint0/Input/Command/LeftItemCommand.cs
@@ -1,0 +1,20 @@
+﻿// Author: Jesse He
+namespace sprint0
+{
+    class LeftCommand : ICommand
+    {
+        private readonly Game1 game;
+
+        public LeftCommand(Game1 game)
+        {
+            this.game = game;
+        }
+
+        public void Execute()
+        {
+            if (game.stateMachine.GetState() != GameStateMachine.State.pause)
+                game.Room.Player.HandleLeft();
+            else game.universalScreenManager.pauseScreenManager.HandleLeft();
+        }
+    }
+}

--- a/sprint0/sprint0/Input/Command/LeftItemCommand.cs
+++ b/sprint0/sprint0/Input/Command/LeftItemCommand.cs
@@ -1,20 +1,19 @@
-﻿// Author: Jesse He
+﻿// Author: Stuti Shah
 namespace sprint0
 {
-    class LeftCommand : ICommand
+    class LeftItemCommand : ICommand
     {
         private readonly Game1 game;
 
-        public LeftCommand(Game1 game)
+        public LeftItemCommand(Game1 game)
         {
             this.game = game;
         }
 
         public void Execute()
         {
-            if (game.stateMachine.GetState() != GameStateMachine.State.pause)
-                game.Room.Player.HandleLeft();
-            else game.universalScreenManager.pauseScreenManager.HandleLeft();
+            if (game.stateMachine.GetState() == GameStateMachine.State.pause)
+                game.universalScreenManager.PauseScreenManager.HandleLeft();
         }
     }
 }

--- a/sprint0/sprint0/Input/Command/PotionCommand.cs
+++ b/sprint0/sprint0/Input/Command/PotionCommand.cs
@@ -1,0 +1,20 @@
+﻿// Author: Stuti Shah
+namespace sprint0
+{
+    class PotionCommand : ICommand
+    {
+        private readonly Game1 game;
+        private HUDManager HUD;
+        private readonly PlayerItems item = PlayerItems.RedPotion;
+        private readonly int health = 2;
+
+        public PotionCommand(Game1 game) => this.game = game;
+
+        public void Execute()
+        {
+            HUD = game.hudManager;
+            HUD.RemoveBItem(item);
+            HUD.GainHealth(health);
+        }
+    }
+}

--- a/sprint0/sprint0/Input/Command/RightCommand.cs
+++ b/sprint0/sprint0/Input/Command/RightCommand.cs
@@ -12,7 +12,8 @@ namespace sprint0
 
         public void Execute()
         {
-            game.Room.Player.HandleRight();
+            if (game.stateMachine.GetState() != GameStateMachine.State.pause)
+                game.Room.Player.HandleRight();
         }
     }
 }

--- a/sprint0/sprint0/Input/Command/RightItemCommand.cs
+++ b/sprint0/sprint0/Input/Command/RightItemCommand.cs
@@ -1,20 +1,19 @@
-﻿// Author: Jesse He
+﻿// Author: Stuti Shah
 namespace sprint0
 {
-    class LeftCommand : ICommand
+    class RightItemCommand : ICommand
     {
         private readonly Game1 game;
 
-        public LeftCommand(Game1 game)
+        public RightItemCommand(Game1 game)
         {
             this.game = game;
         }
 
         public void Execute()
         {
-            if (game.stateMachine.GetState() != GameStateMachine.State.pause)
-                game.Room.Player.HandleLeft();
-            else game.universalScreenManager.pauseScreenManager.HandleLeft();
+            if (game.stateMachine.GetState() == GameStateMachine.State.pause)
+                game.universalScreenManager.PauseScreenManager.HandleRight();
         }
     }
 }

--- a/sprint0/sprint0/Input/Command/RightItemCommand.cs
+++ b/sprint0/sprint0/Input/Command/RightItemCommand.cs
@@ -1,0 +1,20 @@
+﻿// Author: Jesse He
+namespace sprint0
+{
+    class LeftCommand : ICommand
+    {
+        private readonly Game1 game;
+
+        public LeftCommand(Game1 game)
+        {
+            this.game = game;
+        }
+
+        public void Execute()
+        {
+            if (game.stateMachine.GetState() != GameStateMachine.State.pause)
+                game.Room.Player.HandleLeft();
+            else game.universalScreenManager.pauseScreenManager.HandleLeft();
+        }
+    }
+}

--- a/sprint0/sprint0/Input/Command/TwoCommand.cs
+++ b/sprint0/sprint0/Input/Command/TwoCommand.cs
@@ -16,6 +16,7 @@ namespace sprint0
             {
                 game.Room.Player.CurrentItem = PlayerItems.Bomb;
                 game.Room.Player.HandleItem();
+                game.hudManager.RemoveBomb();
             }
         }
     }

--- a/sprint0/sprint0/Input/Controller/KeyboardController.cs
+++ b/sprint0/sprint0/Input/Controller/KeyboardController.cs
@@ -37,23 +37,22 @@ namespace sprint0
             RegisterCommand(Keys.E, new PauseCommand(game));
             RegisterCommand(Keys.Space, new ToggleTestModeCommand(game));
             RegisterCommand(Keys.B, new BItemCommand(game));
-
+            RegisterCommand(Keys.G, new LeftItemCommand(game));
+            RegisterCommand(Keys.H, new RightItemCommand(game));
             RegisterCommand(Keys.M, new ToggleMusicCommand(game));
             RegisterCommand(Keys.OemPeriod, new SkipSongCommand(game));
             RegisterCommand(Keys.OemComma, new ToggleSoundEffectsCommand());
         }
 
         public void RegisterCommand(Keys key, ICommand command)
-        {
-            controllerMappings.Add(key, command);
-        }
+            => controllerMappings.Add(key, command);
 
         public void Update()
         {
             Keys[] pressedKeys = Keyboard.GetState().GetPressedKeys();
 
             foreach (Keys key in pressedKeys)
-                if (controllerMappings.ContainsKey(key) && (Array.IndexOf(previousPressedKeys, key) == -1) || movementKeys.Contains(key))
+                if ((controllerMappings.ContainsKey(key) && (Array.IndexOf(previousPressedKeys, key) == -1)) || movementKeys.Contains(key))
                     controllerMappings[key].Execute();
             foreach (Keys key in movementKeys)
                 if (Array.IndexOf(previousPressedKeys, key) > -1 && Array.IndexOf(pressedKeys, key) == -1)

--- a/sprint0/sprint0/Input/Controller/KeyboardItemController.cs
+++ b/sprint0/sprint0/Input/Controller/KeyboardItemController.cs
@@ -4,14 +4,14 @@ using Microsoft.Xna.Framework.Input;
 
 namespace sprint0
 {
-    class KeyboardController : IController
+    class KeyboardItemController : IController
     {
         private readonly Game1 game;
         private readonly Dictionary<Keys, ICommand> controllerMappings;
         private Keys[] previousPressedKeys;
         private readonly HashSet<Keys> movementKeys;
 
-        public KeyboardController(Game1 game)
+        public KeyboardItemController(Game1 game)
         {
             this.game = game;
             controllerMappings = new Dictionary<Keys, ICommand>();

--- a/sprint0/sprint0/Interfaces/IHUD.cs
+++ b/sprint0/sprint0/Interfaces/IHUD.cs
@@ -10,5 +10,6 @@ namespace sprint0
     {
         public PlayerItems Item { get; set; }
         void SetItem(PlayerItems item);
+        void SetAItem(PlayerItems item);
     }
 }

--- a/sprint0/sprint0/Link/DamagedLink.cs
+++ b/sprint0/sprint0/Link/DamagedLink.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
-//Updated: 03/28/21 by he.1528
+//Updated: 04/03/21 by shah.1440
 namespace sprint0
 {
     class DamagedLink : IPlayer
@@ -10,9 +10,7 @@ namespace sprint0
         private readonly IPlayer decoratedLink;
         private readonly Direction direction;
         private int timer = 80;
-        private readonly PopulateHUDInventory linkInventory;
-        private readonly MainHUD mainHUD;
-        private readonly HUDInventory hudInventory;
+        readonly HUDManager HUD;
         private readonly int speed = 6;
         public Vector2 Pos { get => decoratedLink.Pos; set => decoratedLink.Pos = value; }
         public IPlayerState State { get => decoratedLink.State; set => decoratedLink.State = value; }
@@ -26,9 +24,7 @@ namespace sprint0
             this.game = game;
             this.decoratedLink = decoratedLink;
             this.direction = direction;
-            linkInventory = this.game.hudManager.PopulateHUDInventory;
-            mainHUD = this.game.hudManager.MainHUD;
-            hudInventory = this.game.universalScreenManager.pauseScreenManager.HUDInventory;
+            HUD = this.game.hudManager;
         }
 
         public void Move(int x, int y) => decoratedLink.Move(x, y);
@@ -40,25 +36,16 @@ namespace sprint0
         public void IncrementItem(PlayerItems inventoryItem)
         {
             if (inventoryItem == PlayerItems.BlueRupee)
-                linkInventory.ChangeNum(PlayerItems.Rupee, BlueRupee.Value);
+                HUD.ChangeNum(PlayerItems.Rupee, BlueRupee.Value);
             else if (inventoryItem == PlayerItems.HeartContainer)
-                linkInventory.IncrementItem(PlayerItems.Heart);
-            else linkInventory.IncrementItem(inventoryItem);
+                HUD.Increment(PlayerItems.Heart);
+            else HUD.Increment(inventoryItem);
         }
 
         public void SetHUDItem(PlayerItems source, PlayerItems newItem)
-        {
-            mainHUD.SetItem(source, newItem);
-            hudInventory.SetItem(GetItem(PlayerItems.BItem));
-            hudInventory.AddAItem(GetItem(PlayerItems.AItem));
-        }
+            => HUD.SetItem(source, newItem);
 
-        public PlayerItems GetItem(PlayerItems source)
-        {
-            return mainHUD.GetItem(source);
-        }
-
-        public void AddToInventory(PlayerItems newItem) => hudInventory.AddItem(newItem);
+        public void AddToInventory(PlayerItems newItem) => HUD.AddBItem(newItem);
         public void RemoveDecorator() => game.Room.Player = decoratedLink;
         public void Stop() => decoratedLink.Stop();
         public void HandleUp() => decoratedLink.HandleUp();
@@ -90,7 +77,7 @@ namespace sprint0
         public void ReceiveItem(int n, PlayerItems item)
         {
             decoratedLink.ReceiveItem(n, item);
-            linkInventory.ChangeNum(item, n);
+            HUD.ChangeNum(item, n);
         }
     }
 }

--- a/sprint0/sprint0/Link/IPlayer.cs
+++ b/sprint0/sprint0/Link/IPlayer.cs
@@ -40,7 +40,6 @@ namespace sprint0
         public void HandleItem();
         public void IncrementItem(PlayerItems inventoryItem);
         public void SetHUDItem(PlayerItems source, PlayerItems newItem);
-        public PlayerItems GetItem(PlayerItems source);
         public void AddToInventory(PlayerItems newItem);
         public void ReceiveItem(int n, PlayerItems item);
         public void Draw(SpriteBatch spriteBatch);

--- a/sprint0/sprint0/Link/IPlayer.cs
+++ b/sprint0/sprint0/Link/IPlayer.cs
@@ -13,7 +13,7 @@ namespace sprint0
         Letter = 15, BluePotion = 16, RedPotion = 17, MagicalRod = 18, BookOfMagic = 19, RedRing = 20, MagicalKey = 21,
         PowerBracelet = 22, MagicalBoomerang = 23, Map = 24, Compass = 25, Clock = 26, Fairy = 27, HeartContainer = 28,
         BlueRing = 29, Triforce = 30, Raft = 31, StepLadder = 32,
-        AItem, BItem, HUD
+        AItem, BItem, HUD, ItemSelectorRed, ItemSelectorBlue,
     }
 
     public interface IPlayer : IEntity

--- a/sprint0/sprint0/Screen/CreditsScreen/CreditsScreen.cs
+++ b/sprint0/sprint0/Screen/CreditsScreen/CreditsScreen.cs
@@ -11,7 +11,7 @@ namespace sprint0
     {
         private readonly string message0 = "This game is based on the original Zelda.";
         private readonly string message1 = "It was created for CSE 3902 in Spring 2021 at the OSU";
-        private readonly string message2 = "Its authors include:\n\nNeha Gupta,\n\nJesse He,\n\nHannah Johnson,\n\nAngela Li,\n\nStutti Shah,\n\nJacob Urick";
+        private readonly string message2 = "Its authors include:\n\nNeha Gupta,\n\nJesse He,\n\nHannah Johnson,\n\nAngela Li,\n\nStuti Shah,\n\nJacob Urick";
         private readonly string message3 = "We hope you enjoy it :)";
         private readonly string message4 = "Special thanks to Grace McKenzie and Dr. Matt Bogus for lots of invaluable feedback.";
         private List<Text> textList;
@@ -37,9 +37,11 @@ namespace sprint0
                 new Text(game, message4, new Vector2(xCoord, yCoord*fourthOffset), Color.Black)
             };
         }
-      
-        public void Update() {
-            if (counter > mandatoryCreditsTimer) {
+
+        public void Update()
+        {
+            if (counter > mandatoryCreditsTimer)
+            {
                 counter = 0;
                 textList = new List<Text>
                 {

--- a/sprint0/sprint0/Screen/Pause/PauseScreenManager.cs
+++ b/sprint0/sprint0/Screen/Pause/PauseScreenManager.cs
@@ -21,6 +21,7 @@ namespace sprint0
             pauseScreen = new PauseScreen(this.game);
             hudInventory = new HUDInventory(this.game);
             pauseScreenMap = new PauseScreenMap(this.game);
+            hudInventory.Item = PlayerItems.None;
         }
 
         public void Draw(SpriteBatch spriteBatch)
@@ -32,17 +33,14 @@ namespace sprint0
 
         public void Update()
         {
-            hudInventory.SetItem(game.hudManager.MainHUD.GetItem(PlayerItems.BItem));
             pauseScreenMap.Update();
+            hudInventory.Item = game.hudManager.CurrentItem;
         }
 
-        public Dictionary<PlayerItems, Rectangle> Inventory()
-        {
-            return hudInventory.InventoryItems;
-        }
-        public List<PlayerItems> AItems()
-        {
-            return hudInventory.AItem;
-        }
+        public Dictionary<PlayerItems, Rectangle> Inventory() => hudInventory.InventoryItems;
+
+        public List<PlayerItems> AItems() => hudInventory.AItem;
+
+        public PlayerItems BItem() => hudInventory.Item;
     }
 }

--- a/sprint0/sprint0/Screen/Pause/PauseScreenManager.cs
+++ b/sprint0/sprint0/Screen/Pause/PauseScreenManager.cs
@@ -4,16 +4,17 @@ using System;
 using System.Collections.Generic;
 
 //Author: Stuti Shah
-//Updated: 03/26/21 by shah.1440
+//Updated: 04/03/21 by shah.1440
 namespace sprint0
 {
     public class PauseScreenManager
     {
         private readonly Game1 game;
         private readonly PauseScreen pauseScreen;
-        private HUDInventory hudInventory;
-        private PauseScreenMap pauseScreenMap;
-        public HUDInventory HUDInventory { get => hudInventory; set => hudInventory = value; }
+        private readonly HUDInventory hudInventory;
+        private readonly PauseScreenMap pauseScreenMap;
+        private readonly ItemSelection itemSelection;
+        private bool itemSetup;
 
         public PauseScreenManager(Game1 game)
         {
@@ -22,12 +23,15 @@ namespace sprint0
             hudInventory = new HUDInventory(this.game);
             pauseScreenMap = new PauseScreenMap(this.game);
             hudInventory.Item = PlayerItems.None;
+            itemSelection = new ItemSelection(this.game);
+            itemSetup = true;
         }
 
         public void Draw(SpriteBatch spriteBatch)
         {
             pauseScreen.Draw(spriteBatch);
             hudInventory.Draw(spriteBatch);
+            itemSelection.Draw(spriteBatch);
             pauseScreenMap.Draw(spriteBatch);
         }
 
@@ -35,12 +39,31 @@ namespace sprint0
         {
             pauseScreenMap.Update();
             hudInventory.Item = game.hudManager.CurrentItem;
+            itemSetup = true;
         }
 
-        public Dictionary<PlayerItems, Rectangle> Inventory() => hudInventory.InventoryItems;
-
-        public List<PlayerItems> AItems() => hudInventory.AItem;
-
         public PlayerItems BItem() => hudInventory.Item;
+        public void HandleLeft() => itemSelection.HandleLeft();
+
+        public void HandleRight() => itemSelection.HandleRight();
+
+        public PlayerItems GetSelectedItem() => itemSelection.GetSelectedItem();
+        public void UpdateItemSelection()
+        {
+            itemSelection.Update();
+            if (itemSelection.GetSelectedItem() != PlayerItems.None)
+                hudInventory.Item = itemSelection.GetSelectedItem();
+        }
+
+        public HUDInventory Inventory() => hudInventory;
+        public void SetupItemSelector()
+        {
+            if (itemSetup)
+            {
+                itemSelection.GetCurrentItem(hudInventory.Item);
+                itemSelection.GetInventory(hudInventory.InventoryItems);
+                itemSetup = false;
+            }
+        }
     }
 }

--- a/sprint0/sprint0/Screen/Pause/PauseScreenMap.cs
+++ b/sprint0/sprint0/Screen/Pause/PauseScreenMap.cs
@@ -22,9 +22,9 @@ namespace sprint0
 
         public void Draw(SpriteBatch spriteBatch)
         {
-            if (game.hudManager.HasMap())
+            if (game.hudManager.HasItem(PlayerItems.Map))
                 DrawMap(spriteBatch);
-            if (game.hudManager.HasCompass())
+            if (game.hudManager.HasItem(PlayerItems.Compass))
                 spriteBatch.Draw(Texture, new Rectangle(roomPos[currentRoom].X + 6, roomPos[currentRoom].Y + 6, roomPos[currentRoom].Width, roomPos[currentRoom].Height), sources[(int)RoomDirection.Location], Color.White);
         }
 

--- a/sprint0/sprint0/Screen/UniversalScreenManager.cs
+++ b/sprint0/sprint0/Screen/UniversalScreenManager.cs
@@ -1,15 +1,19 @@
 ﻿using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-
+//Author: Stuti Shah
 namespace sprint0
 {
     public class UniversalScreenManager
     {
-        public PauseScreenManager pauseScreenManager;
+        private PauseScreenManager pauseScreenManager;
+        public PauseScreenManager PauseScreenManager { get => pauseScreenManager; }
         public GameOverScreenManager gameOverScreenManager;
         public StartScreenManager startScreenManager;
         public CreditsScreenManager creditsScreenManager;
         public VictoryScreenManager victorScreenManager;
+        public ItemSelection itemSelection;
 
         public UniversalScreenManager(Game1 game)
         {
@@ -22,9 +26,9 @@ namespace sprint0
 
         public void Update(GameStateMachine.State state)
         {
-            if (state.Equals(GameStateMachine.State.pause))
+            if (!state.Equals(GameStateMachine.State.pause))
                 pauseScreenManager.Update();
-            else if (state.Equals(GameStateMachine.State.over))
+            if (state.Equals(GameStateMachine.State.over))
                 gameOverScreenManager.Update();
             else if (state.Equals(GameStateMachine.State.credits))
                 creditsScreenManager.Update();
@@ -32,6 +36,11 @@ namespace sprint0
                 startScreenManager.Update();
             else if (state.Equals(GameStateMachine.State.win))
                 victorScreenManager.Update();
+            else if (state.Equals(GameStateMachine.State.pause))
+            {
+                pauseScreenManager.SetupItemSelector();
+                pauseScreenManager.UpdateItemSelection();
+            }
         }
 
         public void Draw(SpriteBatch _spriteBatch, GameStateMachine.State state)
@@ -48,5 +57,7 @@ namespace sprint0
             else if (state.Equals(GameStateMachine.State.win))
                 victorScreenManager.Draw(_spriteBatch);
         }
+
+        public PlayerItems BItem() => pauseScreenManager.BItem();
     }
 }

--- a/sprint0/sprint0/Screen/Victory Screen/VictoryScreen.cs
+++ b/sprint0/sprint0/Screen/Victory Screen/VictoryScreen.cs
@@ -9,7 +9,7 @@ namespace sprint0
 {
     public class VictoryScreen
     {
-        private readonly string message = "Congratulations, brave adventorer!\n\nYou've won!\n\nPress R to restart or Q to quit.";
+        private readonly string message = "Congratulations, brave adventurer!\n\nYou've won!\n\nPress R to restart or Q to quit.";
         private readonly Text text;
         private readonly int xCoord = 150;
         private readonly int yCoord = 150;
@@ -18,9 +18,9 @@ namespace sprint0
             text = new Text(game, message, new Vector2(xCoord, yCoord), Color.Black);
         }
 
-        public void Draw(SpriteBatch spriteBatch) 
+        public void Draw(SpriteBatch spriteBatch)
         {
-            text.Draw(spriteBatch);   
+            text.Draw(spriteBatch);
         }
     }
 }


### PR DESCRIPTION
- Using BItem
- food and red potion heals
- changes to how the hud interects with link and how it's setup.
- (con't from above): HUD manager now controls all of the hud stuff fully. Link only needs the HUD manager now. No populateHUD or MainHUD or HUD Inventory. All functionality from before can be accessed through public methods in the HUDManager
- item selection (be able to choose the item in the B slot from the pause menu)
- One-time use items (food, red potion) disappear from the B slot in the HUD and from the pause menu upon use
- Bomb is disappear from hud and inventory if # of bombs is 0
- when selecting items, if there's a missing item between two items, the item selector will skip over the empty slot and go to the next filled inventory slot
- resolved (hopefully) all merge conflicts
- "Stutti" -> "Stuti"

New controls:
- B: when in play/test mode, use B to use the item in the B slot. In pause mode, use B to select the item and exit from the pause menu (controlled by BItemCommand)
- G: go left an item on item selection (controlled by LeftItemCommand)
- H: go right an item on item selection (controlled by RightItemCommand)

Bugs:
- syncing and selecting between items that occupy the same inventory slot (ie blue/red potion, blue/red candle, etc) is not consistent. haven't quite decided what to do about that
- blue potion isn't removed from inventory when used; nbd. i'll just make a diff command for it. not doing it right now though since i don't know what the blue potion does. Also having to deal with two kinds of the same item is part of the reason that hud inventory is so long. i need to think about what to do