### PR TITLE
max health, link spawn, item bug fix

### DIFF
--- a/sprint0/sprint0/Content/LevelData/Room12.xml
+++ b/sprint0/sprint0/Content/LevelData/Room12.xml
@@ -15,7 +15,7 @@
  
     <Block ObjectName="block" LocationX="160" LocationY="380" />? 
     <Block ObjectName="block" LocationX="440" LocationY="380" />?  
-    
+    <Item ObjectName="key" LocationX="280" LocationY="340" />?
     <Boss ObjectName="dodongo" LocationX="320" LocationY="340" />? 
     <Boss ObjectName="dodongo" LocationX="240" LocationY="300" />? 
     <Boss ObjectName="dodongo" LocationX="360" LocationY="300" />? 

--- a/sprint0/sprint0/Content/LevelData/Room12.xml
+++ b/sprint0/sprint0/Content/LevelData/Room12.xml
@@ -15,7 +15,6 @@
  
     <Block ObjectName="block" LocationX="160" LocationY="380" />? 
     <Block ObjectName="block" LocationX="440" LocationY="380" />?  
-    <Item ObjectName="key" LocationX="280" LocationY="340" />?
     <Boss ObjectName="dodongo" LocationX="320" LocationY="340" />? 
     <Boss ObjectName="dodongo" LocationX="240" LocationY="300" />? 
     <Boss ObjectName="dodongo" LocationX="360" LocationY="300" />? 

--- a/sprint0/sprint0/Content/LevelData/Room13.xml
+++ b/sprint0/sprint0/Content/LevelData/Room13.xml
@@ -18,7 +18,6 @@
      <Item ObjectName="white sword" LocationX="200" LocationY="340" />?
     
     <Boss ObjectName="gleeok" LocationX="280" LocationY="275" />? 
-    
     <Player ObjectName="Link" LocationX="80" LocationY="340" />?
     
 ?</XnaContent>

--- a/sprint0/sprint0/Content/LevelData/Room18.xml
+++ b/sprint0/sprint0/Content/LevelData/Room18.xml
@@ -15,17 +15,14 @@
       <Item ObjectName="candle" LocationX="280" LocationY="220" />?
       <Item ObjectName="meat" LocationX="320" LocationY="220" />?
       <Item ObjectName="blue map" LocationX="360" LocationY="220" />?
-       <Item ObjectName="map" LocationX="400" LocationY="220" />?
-        <Item ObjectName="blue potion" LocationX="440" LocationY="220" />?
-         <Item ObjectName="potion" LocationX="480" LocationY="220" />?
-          <Item ObjectName="blue rupee" LocationX="520" LocationY="220" />?
-
-           <Item ObjectName="rupee" LocationX="80" LocationY="460" />?
+      <Item ObjectName="map" LocationX="400" LocationY="220" />?
+      <Item ObjectName="blue potion" LocationX="440" LocationY="220" />?
+      <Item ObjectName="potion" LocationX="480" LocationY="220" />?
+      <Item ObjectName="blue rupee" LocationX="520" LocationY="220" />?
+      <Item ObjectName="rupee" LocationX="80" LocationY="460" />?
       <Item ObjectName="clock" LocationX="120" LocationY="460" />?
      <Item ObjectName="bow" LocationX="160" LocationY="460" />?
       <Item ObjectName="heart container" LocationX="200" LocationY="460" />?
-      <Item ObjectName="triforce piece" LocationX="240" LocationY="460" />?
-      <Item ObjectName="triforce piece" LocationX="280" LocationY="460" />?
       <Item ObjectName="compass" LocationX="320" LocationY="460" />?
       <Item ObjectName="key" LocationX="360" LocationY="460" />?
        <Item ObjectName="fairy" LocationX="400" LocationY="460" />?

--- a/sprint0/sprint0/Content/LevelData/Room2.xml
+++ b/sprint0/sprint0/Content/LevelData/Room2.xml
@@ -36,9 +36,7 @@
 
     <Block ObjectName="water" LocationX="400" LocationY="420" />?
     <Block ObjectName="water" LocationX="440" LocationY="420" />?
-    <Block ObjectName="water" LocationX="480" LocationY="420" />?
-    <Item ObjectName="key" LocationX="300" LocationY="260" />?
-    
+    <Block ObjectName="water" LocationX="480" LocationY="420" />?    
 
     <Enemy ObjectName="red goriya" LocationX="360" LocationY="260" />?
     <Enemy ObjectName="red goriya" LocationX="360" LocationY="220" />?

--- a/sprint0/sprint0/Content/LevelData/Room2.xml
+++ b/sprint0/sprint0/Content/LevelData/Room2.xml
@@ -37,7 +37,7 @@
     <Block ObjectName="water" LocationX="400" LocationY="420" />?
     <Block ObjectName="water" LocationX="440" LocationY="420" />?
     <Block ObjectName="water" LocationX="480" LocationY="420" />?
-   
+    <Item ObjectName="key" LocationX="300" LocationY="260" />?
     
 
     <Enemy ObjectName="red goriya" LocationX="360" LocationY="260" />?

--- a/sprint0/sprint0/Content/LevelData/Room3.xml
+++ b/sprint0/sprint0/Content/LevelData/Room3.xml
@@ -59,7 +59,7 @@
     <Block ObjectName="water" LocationX="440" LocationY="460" />?
     <Block ObjectName="water" LocationX="480" LocationY="460" />?
     <Block ObjectName="water" LocationX="520" LocationY="460" />?
-    
+        <Item ObjectName="key" LocationX="485" LocationY="300" />?
      <Enemy ObjectName="stalfos" LocationX="120" LocationY="340" />?
     <Enemy ObjectName="stalfos" LocationX="320" LocationY="260" />?
     <Enemy ObjectName="stalfos" LocationX="320" LocationY="480" />?

--- a/sprint0/sprint0/Content/LevelData/Room3.xml
+++ b/sprint0/sprint0/Content/LevelData/Room3.xml
@@ -59,7 +59,6 @@
     <Block ObjectName="water" LocationX="440" LocationY="460" />?
     <Block ObjectName="water" LocationX="480" LocationY="460" />?
     <Block ObjectName="water" LocationX="520" LocationY="460" />?
-        <Item ObjectName="key" LocationX="485" LocationY="300" />?
      <Enemy ObjectName="stalfos" LocationX="120" LocationY="340" />?
     <Enemy ObjectName="stalfos" LocationX="320" LocationY="260" />?
     <Enemy ObjectName="stalfos" LocationX="320" LocationY="480" />?

--- a/sprint0/sprint0/Content/LevelData/Room4.xml
+++ b/sprint0/sprint0/Content/LevelData/Room4.xml
@@ -8,8 +8,8 @@
     <Dungeon ObjectName="left open door" LocationX="560" LocationY="320" />?    
     <Dungeon ObjectName="right wall" LocationX="0" LocationY="320" />?
 
-	<NPC ObjectName="white merchant" LocationX="80" LocationY="400" />?
-	<NPC ObjectName="old man 1" LocationX="300" LocationY="300" />?
+    <NPC ObjectName="white merchant" LocationX="80" LocationY="400" />?
+    <NPC ObjectName="old man 1" LocationX="300" LocationY="300" />?
     <Item ObjectName="wooden sword" LocationX="310" LocationY="375" />?
     <NPC ObjectName="flame" LocationX="200" LocationY="300" />?
     <NPC ObjectName="flame" LocationX="400" LocationY="300" />?

--- a/sprint0/sprint0/Content/LevelData/Room6.xml
+++ b/sprint0/sprint0/Content/LevelData/Room6.xml
@@ -20,7 +20,6 @@
     <Block ObjectName="block" LocationX="160" LocationY="420" />?
     <Block ObjectName="block" LocationX="440" LocationY="420" />?
     <Block ObjectName="block" LocationX="480" LocationY="420" />? 
-    
      <Enemy ObjectName="gold zol" LocationX="160" LocationY="220" />?
     <Enemy ObjectName="green zol" LocationX="200" LocationY="300" />?
     <Enemy ObjectName="lime zol" LocationX="360" LocationY="220" />?

--- a/sprint0/sprint0/Game1.cs
+++ b/sprint0/sprint0/Game1.cs
@@ -68,7 +68,7 @@ namespace sprint0
 
             stateMachine.HandleStart();
             VisitedRooms = new List<int>();
-            RoomIndex = 18;
+            RoomIndex = 16;
             ChangeRoom = true;
             UseLoadedPos = false;
             base.Initialize();
@@ -85,7 +85,7 @@ namespace sprint0
         {
             ResetElapsedTime();
             VisitedRooms.Clear();
-            RoomIndex = 18;
+            RoomIndex = 16;
             ChangeRoom = true;
             ResetManagers();
             Player = new Link(this, new Vector2(LinkDefaultX, LinkDefaultY));

--- a/sprint0/sprint0/HUD/HUDInventory.cs
+++ b/sprint0/sprint0/HUD/HUDInventory.cs
@@ -50,7 +50,7 @@ namespace sprint0
 
         public void AddAItem(PlayerItems newItem)
         {
-            if (!aItem.Contains(newItem) && ItemMap.ContainsKey(newItem))
+            if (!aItem.Contains(newItem) && LocationMapping.ContainsKey(newItem))
                 aItem.Add(newItem);
         }
 

--- a/sprint0/sprint0/HUD/HUDInventory.cs
+++ b/sprint0/sprint0/HUD/HUDInventory.cs
@@ -37,7 +37,7 @@ namespace sprint0
 
         public void SetItem(PlayerItems item)
         {
-            if (HasItem(item) || item == PlayerItems.None)
+            if (HasItem(item) || item == PlayerItems.None && item != PlayerItems.Map && item != PlayerItems.Letter)
                 Item = item;
         }
 

--- a/sprint0/sprint0/HUD/HUDInventory.cs
+++ b/sprint0/sprint0/HUD/HUDInventory.cs
@@ -37,7 +37,7 @@ namespace sprint0
 
         public void SetItem(PlayerItems item)
         {
-            if (HasItem(item) || item == PlayerItems.None && item != PlayerItems.Map && item != PlayerItems.Letter)
+            if (HasItem(item) || item == PlayerItems.None)
                 Item = item;
         }
 

--- a/sprint0/sprint0/HUD/HUDItem.cs
+++ b/sprint0/sprint0/HUD/HUDItem.cs
@@ -33,16 +33,19 @@ namespace sprint0
 
         public void SetAItem(PlayerItems item)
         {
-            if ((ItemMap.ContainsKey(item) && IsSword(item)) || item == PlayerItems.None)
+            if ((HasItem(item) && IsSword(item)) || IsNone(item))
                 Item = item;
         }
         public void SetItem(PlayerItems item)
         {
-            if (ItemMap.ContainsKey(item) && Item == PlayerItems.None || item == PlayerItems.None)
+            if ((HasItem(item) && !IsMapOrLetter(item) && IsNone(Item)) || IsNone(item))
                 Item = item;
         }
 
         private bool SmallItem() => Item != PlayerItems.Compass && Item != PlayerItems.Raft && Item != PlayerItems.StepLadder;
         private bool IsSword(PlayerItems item) => item == PlayerItems.Sword || item == PlayerItems.MagicalSword || item == PlayerItems.WhiteSword;
+        private bool IsMapOrLetter(PlayerItems item) => item == PlayerItems.Map || item == PlayerItems.Letter;
+        private bool HasItem(PlayerItems item) => ItemMap.ContainsKey(item);
+        private bool IsNone(PlayerItems item) => item == PlayerItems.None;
     }
 }

--- a/sprint0/sprint0/HUD/HUDItem.cs
+++ b/sprint0/sprint0/HUD/HUDItem.cs
@@ -38,7 +38,7 @@ namespace sprint0
         }
         public void SetItem(PlayerItems item)
         {
-            if ((HasItem(item) && !IsMapOrLetter(item) && IsNone(Item)) || IsNone(item))
+            if ((HasItem(item) && IsValidBItem(item) && IsNone(Item)) || IsNone(item))
                 Item = item;
         }
 
@@ -46,6 +46,7 @@ namespace sprint0
         private bool IsSword(PlayerItems item) => item == PlayerItems.Sword || item == PlayerItems.MagicalSword || item == PlayerItems.WhiteSword;
         private bool IsMapOrLetter(PlayerItems item) => item == PlayerItems.Map || item == PlayerItems.Letter;
         private bool HasItem(PlayerItems item) => ItemMap.ContainsKey(item);
+        private bool IsValidBItem(PlayerItems item) => !TopRowItems.Contains(item) && !IsMapOrLetter(item);
         private bool IsNone(PlayerItems item) => item == PlayerItems.None;
     }
 }

--- a/sprint0/sprint0/HUD/HUDItemMapping.cs
+++ b/sprint0/sprint0/HUD/HUDItemMapping.cs
@@ -10,8 +10,10 @@ namespace sprint0
     public class HUDItemMapping
     {
         protected readonly Dictionary<PlayerItems, Rectangle> itemMap, locationMapping;
+        protected readonly List<PlayerItems> topRowItems;
         public Dictionary<PlayerItems, Rectangle> ItemMap { get => itemMap; }
         public Dictionary<PlayerItems, Rectangle> LocationMapping { get => locationMapping; }
+        public List<PlayerItems> TopRowItems { get => topRowItems; }
         public Rectangle CurrentItem { get => currentItem; }
         private readonly int height = 16, smallWidth = 8, bigWidth = 16, yPosTop = 24, yPosMiddle = 48, yPosBottom = 64, currentItemX = 68, mapHeight = 88;
         private readonly Rectangle currentItem;
@@ -52,7 +54,7 @@ namespace sprint0
                 { PlayerItems.ItemSelectorRed, GetSourceRaftLadder(519, YPos)},
                 { PlayerItems.ItemSelectorBlue, GetSourceRaftLadder(536, YPos)},
             };
-
+            topRowItems = new List<PlayerItems> { PlayerItems.Raft, PlayerItems.BookOfMagic, PlayerItems.StepLadder, PlayerItems.MagicalKey, PlayerItems.PowerBracelet, PlayerItems.RedRing };
             locationMapping = new Dictionary<PlayerItems, Rectangle>
             {
                 { PlayerItems.Raft, GetSource(129, yPosTop, bigWidth, height)},

--- a/sprint0/sprint0/HUD/HUDManager.cs
+++ b/sprint0/sprint0/HUD/HUDManager.cs
@@ -65,7 +65,7 @@ namespace sprint0
         public void SetItem(PlayerItems source, PlayerItems item)
         {
             mainHUD.SetItem(source, item);
-            if (source == PlayerItems.BItem)
+            if (source == PlayerItems.BItem && item != PlayerItems.Map)
                 pauseInventory.SetItem(item);
             else pauseInventory.AddAItem(item);
         }

--- a/sprint0/sprint0/HUD/HeartHUD.cs
+++ b/sprint0/sprint0/HUD/HeartHUD.cs
@@ -14,18 +14,20 @@ namespace sprint0
         public int CurrentNum { get => currentHealth; }
         private readonly int[] heartState;
         private readonly List<Rectangle> sources;
-        private readonly int sideLength = 8, heartType = 3, heartsPerRow = 8,
+        private const int heartType = 3;
+        private readonly int sideLength = 8, heartsPerRow = 8,
             healthToHeart = 2, reset = 0, xOffset = 627,
             yOffset = 117, maxPossibleHearts = 32;
-        private int currentHealth, numHearts = 15, maxHealth = 30;
+        private int currentHealth, numHearts, maxHealth = 28;
 
         public HeartHUD(Texture2D texture, Vector2 location)
         {
             Location = new Rectangle((int)location.X, (int)location.Y, 0, 0);
             Texture = texture;
-            heartState = new int[3] { reset, reset, numHearts };
+            numHearts = maxHealth / 2;
+            heartState = new int[heartType] { reset, reset, numHearts };
             ResetNum();
-            int totalFrames = 3;
+            int totalFrames = heartType;
             sources = SpritesheetHelper.GetFramesH(xOffset, yOffset, sideLength, sideLength, totalFrames);
         }
 

--- a/sprint0/sprint0/HUD/ItemSelection.cs
+++ b/sprint0/sprint0/HUD/ItemSelection.cs
@@ -10,7 +10,7 @@ namespace sprint0
         private List<PlayerItems> itemList;
         public Rectangle Location { get; set; }
         private Dictionary<PlayerItems, Rectangle> inventoryItems;
-        private readonly int itemNum = 19, totalFrames = 2, repeatedFrames = 30;
+        private readonly int itemNum = 13, totalFrames = 2, repeatedFrames = 30;
         private int index, currentFrame = 0, pos;
         private readonly List<Rectangle> sources;
         public Texture2D Texture { get; set; }
@@ -21,12 +21,6 @@ namespace sprint0
             inventoryItems = new Dictionary<PlayerItems, Rectangle>();
             sources = new List<Rectangle> { ItemMap[PlayerItems.ItemSelectorRed], ItemMap[PlayerItems.ItemSelectorBlue] };
             itemList = new List<PlayerItems> {
-                PlayerItems.Raft,
-                PlayerItems.BookOfMagic,
-                PlayerItems.RedRing,
-                PlayerItems.StepLadder,
-                PlayerItems.MagicalKey,
-                PlayerItems.PowerBracelet,
                 PlayerItems.MagicalBoomerang,
                 PlayerItems.Boomerang,
                 PlayerItems.Bomb,

--- a/sprint0/sprint0/Link/Link.cs
+++ b/sprint0/sprint0/Link/Link.cs
@@ -11,8 +11,7 @@ namespace sprint0
         private readonly Game1 game;
         private IPlayerState state;
         public static Vector2 position;
-        private int health = 32;
-        private readonly int maxHealth = 32;
+        private int health = 28, maxHealth = 28;
         private readonly int speed = 2;
         private bool isAlive;
         private Direction direction = Direction.n;
@@ -60,7 +59,11 @@ namespace sprint0
             if (inventoryItem == PlayerItems.BlueRupee)
                 HUD.ChangeNum(PlayerItems.Rupee, BlueRupee.Value);
             else if (inventoryItem == PlayerItems.HeartContainer)
+            {
                 HUD.Increment(PlayerItems.Heart);
+                maxHealth += 2;
+            }
+
             else HUD.Increment(inventoryItem);
         }
 


### PR DESCRIPTION
- adjusted link max health (and heart hud) for heart containers
- (undone) adding keys in rooms that were missing needed keys
- link now spawns in room 16
- fixed bug that causes game to crash if you picked up letter or map
- top row items can't be in B Item slot (i.e raft, ladder, red ring, magical key, power bracelet, book of magic)